### PR TITLE
feat: validate address and add letterhead and signature options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 template_files/
 template.pdf
 template.tex
+
+/.luarc.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## Unreleased
 
-No user-facing changes.
+### New Features
+
+- feat: Add `signature-image` (and `signature-image-width`) for inserting a digital signature image between the closing and the printed name.
+- feat: Add `header-image` (and `header-image-width`) for letterhead images inserted above the opening salutation.
+- feat: Add a French bilingual snippet (`meta-fr`) and a signature-image snippet (`meta-sig`).
+- feat: Add a Lua filter that validates the required `address` field and warns on raw HTML tokens in `subject` or `subject-title`.
+
+### Documentation
+
+- docs: Document the new image options and the French (bilingual) example in the README.
 
 ## 1.1.0 (2026-02-21)
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,61 @@ or in your document yaml
 format: letter-pdf
 ```
 
-It's possible to change the subject title and the subject suffix, e.g., for a French letter:
+### Configuration
+
+| Option                  | Type   | Default      | Description                                                                                                 |
+| ----------------------- | ------ | ------------ | ----------------------------------------------------------------------------------------------------------- |
+| `address`               | array  | (required)   | Recipient address lines. The render logs an error if missing or empty.                                      |
+| `subject`               | string |              | Letter subject line.                                                                                        |
+| `subject-title`         | string | `Subject`    | Label preceding the subject line.                                                                           |
+| `subject-suffix`        | string | `:`          | Character appended after the subject title.                                                                 |
+| `opening`               | string |              | Opening salutation.                                                                                         |
+| `closing`               | string |              | Closing salutation.                                                                                         |
+| `cc`                    | array  |              | Carbon copy recipients.                                                                                     |
+| `encl`                  | array  |              | List of enclosures.                                                                                         |
+| `ps`                    | string |              | Postscript text appended after the closing.                                                                 |
+| `header-image`          | string |              | Path to a letterhead image inserted above the opening salutation.                                           |
+| `header-image-width`    | string | `\textwidth` | LaTeX width for the letterhead image (e.g. `0.5\textwidth`, `8cm`).                                         |
+| `signature-image`       | string |              | Path to a signature image inserted between the closing salutation and the printed name (digital signature). |
+| `signature-image-width` | string | `4cm`        | LaTeX width for the signature image (e.g. `4cm`, `0.3\textwidth`).                                          |
+
+### Bilingual Variants
+
+It is possible to change the subject title and the subject suffix, e.g., for a French letter:
 
 ```yaml
-subject-title: Objet
-subject-suffix: "&nbsp;:"
+format:
+  letter-pdf:
+    subject-title: Objet
+    subject-suffix: "&nbsp;:"
 ```
+
+The extension ships matching code snippets (`meta` for English, `meta-fr` for French, `meta-sig` for a letter with a signature image) that can be triggered in editors with Quarto IDE integration.
+
+### Letterhead and Signature Images
+
+To include a letterhead and a digital signature image:
+
+```yaml
+format:
+  letter-pdf:
+    header-image: letterhead.png
+    header-image-width: "0.5\\textwidth"
+    signature-image: signature.png
+    signature-image-width: 4cm
+```
+
+> [!NOTE]
+> Width values are passed through to `\includegraphics`, so any LaTeX dimension is accepted (e.g. `4cm`, `0.5\textwidth`, `120pt`).
+> Use double backslashes in YAML double-quoted strings (`"0.5\\textwidth"`) so the literal backslash is preserved.
+
+### Validation and Warnings
+
+The extension emits prefixed diagnostics during rendering:
+
+- An error when the required `address` field is missing or empty.
+- A warning when `subject-title` is set but `subject` is empty.
+- A warning when `subject` or `subject-title` contains raw HTML tokens (e.g. `<x>`), which Pandoc strips from LaTeX output.
 
 You can view a preview of the rendered template at <https://m.canouil.dev/quarto-letter/index.pdf>.
 

--- a/_extensions/letter/_extension.yml
+++ b/_extensions/letter/_extension.yml
@@ -7,6 +7,8 @@ contributes:
     common:
       date: today
       date-format: long
+      filters:
+        - letter.lua
     pdf:
       documentclass: letter
       geometry:

--- a/_extensions/letter/_modules/logging.lua
+++ b/_extensions/letter/_modules/logging.lua
@@ -1,0 +1,62 @@
+--- MC Logging - Formatted log output for Quarto Lua filters and shortcodes
+--- @module "logging"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 1.0.0
+
+local M = {}
+
+-- ============================================================================
+-- LOGGING UTILITIES
+-- ============================================================================
+
+--- Format and log an error message with extension prefix.
+--- Provides standardised error messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "external", "lua-env")
+--- @param message string The error message to display
+--- @usage M.log_error("external", "Could not open file 'example.md'.")
+function M.log_error(extension_name, message)
+  quarto.log.error('[' .. extension_name .. '] ' .. message)
+end
+
+--- Format and log a warning message with extension prefix.
+--- Provides standardised warning messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "external", "lua-env")
+--- @param message string The warning message to display
+--- @usage M.log_warning("lua-env", "No variable name provided.")
+function M.log_warning(extension_name, message)
+  quarto.log.warning('[' .. extension_name .. '] ' .. message)
+end
+
+--- Format and log an output message with extension prefix.
+--- Provides standardised informational messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "lua-env")
+--- @param message string The informational message to display
+--- @usage M.log_output("lua-env", "Exported metadata to: output.json")
+function M.log_output(extension_name, message)
+  quarto.log.output('[' .. extension_name .. '] ' .. message)
+end
+
+--- Format and log a debug message with extension prefix.
+--- Provides standardised debug messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "lua-env")
+--- @param message string The debug message to display
+--- @usage M.log_debug("lua-env", "Variable 'x' has value: 42")
+function M.log_debug(extension_name, message)
+  quarto.log.debug('[' .. extension_name .. '] ' .. message)
+end
+
+-- ============================================================================
+-- MODULE EXPORT
+-- ============================================================================
+
+return M

--- a/_extensions/letter/_schema.yml
+++ b/_extensions/letter/_schema.yml
@@ -12,7 +12,7 @@ formats:
       type: array
       required: true
       min-items: 1
-      description: "Recipient address lines."
+      description: "Recipient address lines (required)."
       items:
         type: string
     subject:
@@ -45,3 +45,17 @@ formats:
     ps:
       type: string
       description: "Postscript text appended after the closing."
+    header-image:
+      type: string
+      description: "Path to a letterhead image inserted above the opening salutation."
+    header-image-width:
+      type: string
+      default: "\\textwidth"
+      description: "LaTeX width for the letterhead image (e.g. '0.5\\textwidth', '8cm')."
+    signature-image:
+      type: string
+      description: "Path to a signature image inserted between the closing and the printed name."
+    signature-image-width:
+      type: string
+      default: "4cm"
+      description: "LaTeX width for the signature image (e.g. '4cm', '0.3\\textwidth')."

--- a/_extensions/letter/_schema.yml
+++ b/_extensions/letter/_schema.yml
@@ -1,17 +1,17 @@
-# _schema.yml for "letter" format extension
+# Schema for the letter extension
 # Describes format-specific options for IDE tooling and runtime validation.
 
 # Per-format schemas.
 # Options configured under format: letter-pdf: in YAML metadata.
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 formats:
   letter-pdf:
     address:
       type: array
       required: true
-      min-items: 1
+      minItems: 1
       description: "Recipient address lines (required)."
       items:
         type: string

--- a/_extensions/letter/_snippets.json
+++ b/_extensions/letter/_snippets.json
@@ -1,5 +1,5 @@
 {
-	"Letter front matter": {
+	"Letter front matter (English)": {
 		"prefix": "meta",
 		"body": [
 			"---",
@@ -16,6 +16,50 @@
 			"closing: \"${8:Yours faithfully,}\"",
 			"---"
 		],
-		"description": "Letter format document front matter"
+		"description": "Letter format document front matter (English)."
+	},
+	"Letter front matter (French)": {
+		"prefix": "meta-fr",
+		"body": [
+			"---",
+			"title: \"${1:Titre de la lettre}\"",
+			"author: \"${2:Votre nom}\"",
+			"date: today",
+			"format:",
+			"  letter-pdf:",
+			"    subject-title: \"Objet\"",
+			"    subject-suffix: \"&nbsp;:\"",
+			"address:",
+			"  - \"${3:Nom du destinataire}\"",
+			"  - \"${4:35 rue de l'Exemple}\"",
+			"  - \"${5:75000 Paris}\"",
+			"subject: \"${6:Objet de la lettre}\"",
+			"opening: \"${7:Madame, Monsieur,}\"",
+			"closing: \"${8:Je vous prie d'agréer, Madame, Monsieur, mes salutations distinguées.}\"",
+			"---"
+		],
+		"description": "Letter format document front matter (French)."
+	},
+	"Letter with signature image": {
+		"prefix": "meta-sig",
+		"body": [
+			"---",
+			"title: \"${1:Letter Title}\"",
+			"author: \"${2:Your Name}\"",
+			"date: today",
+			"format:",
+			"  letter-pdf:",
+			"    signature-image: ${3:signature.png}",
+			"    signature-image-width: ${4:4cm}",
+			"address:",
+			"  - \"${5:Recipient Name}\"",
+			"  - \"${6:123 Recipient Road}\"",
+			"  - \"${7:London, EC1A 1BB}\"",
+			"subject: \"${8:Letter Subject}\"",
+			"opening: \"${9:Dear Sir or Madam,}\"",
+			"closing: \"${10:Yours faithfully,}\"",
+			"---"
+		],
+		"description": "Letter format front matter with a signature image."
 	}
 }

--- a/_extensions/letter/letter.lua
+++ b/_extensions/letter/letter.lua
@@ -3,7 +3,6 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 1.2.0
 --- @brief Validate front matter and prepare letterhead/signature assets.
 --- @description Validates required fields for the letter-pdf format and
 --- prepares optional `header-image` and `signature-image` blocks so the
@@ -92,7 +91,6 @@ end
 
 --- Validate that the recipient address is present and well formed.
 --- @param meta table Pandoc document metadata
---- @return boolean ok true when validation succeeds
 local function validate_address(meta)
   if not list_has_entries(meta['address']) then
     log.log_error(
@@ -100,9 +98,7 @@ local function validate_address(meta)
       "Missing required 'address' field. " ..
       "Add at least one recipient address line under format.letter-pdf.address."
     )
-    return false
   end
-  return true
 end
 
 --- Detect a RawInline carrying an HTML tag inside a Pandoc inline list.

--- a/_extensions/letter/letter.lua
+++ b/_extensions/letter/letter.lua
@@ -1,0 +1,233 @@
+--- Letter - Format Filter
+--- @module "letter"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 1.2.0
+--- @brief Validate front matter and prepare letterhead/signature assets.
+--- @description Validates required fields for the letter-pdf format and
+--- prepares optional `header-image` and `signature-image` blocks so the
+--- LaTeX template can render them without bespoke escaping in the partials.
+
+local EXTENSION_NAME = 'letter'
+local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
+
+--- Convert a metadata value to a trimmed string.
+--- @param value any Pandoc metadata value or nil
+--- @return string trimmed Trimmed plain-text value, empty string if absent
+local function meta_to_string(value)
+  if value == nil then
+    return ''
+  end
+  local text = pandoc.utils.stringify(value)
+  return text:gsub('^%s+', ''):gsub('%s+$', '')
+end
+
+--- Check that a metadata list has at least one non-empty entry.
+--- @param value any Pandoc metadata value (expected to be a List)
+--- @return boolean has_entries true when the list contains usable lines
+local function list_has_entries(value)
+  if value == nil then
+    return false
+  end
+  if type(value) ~= 'table' then
+    return meta_to_string(value) ~= ''
+  end
+  for _, item in ipairs(value) do
+    if meta_to_string(item) ~= '' then
+      return true
+    end
+  end
+  return false
+end
+
+--- Reconstruct a LaTeX width string from Pandoc inline metadata.
+--- Plain `Str` text is concatenated; `RawInline` content is kept verbatim so
+--- LaTeX dimensions like `0.5\textwidth` survive the YAML round trip.
+--- @param value any Pandoc metadata value (MetaInlines or similar)
+--- @return string text Combined text representation
+local function inlines_to_latex(value)
+  if value == nil then
+    return ''
+  end
+  if type(value) ~= 'table' then
+    return meta_to_string(value)
+  end
+  local parts = {}
+  pandoc.walk_inline(pandoc.Span(value), {
+    Str = function(el)
+      parts[#parts + 1] = el.text
+    end,
+    Space = function()
+      parts[#parts + 1] = ' '
+    end,
+    RawInline = function(el)
+      parts[#parts + 1] = el.text
+    end
+  })
+  local text = table.concat(parts)
+  return text:gsub('^%s+', ''):gsub('%s+$', '')
+end
+
+--- Resolve a width string for graphics inclusion in LaTeX.
+--- Falls back to the supplied default when the value is empty.
+--- @param value any Metadata value carrying a width (e.g. "4cm", "0.5\\textwidth")
+--- @param default string Default width to use when value is empty
+--- @return string width Width string suitable for \includegraphics
+local function resolve_width(value, default)
+  local width = inlines_to_latex(value)
+  if width == '' then
+    return default
+  end
+  return width
+end
+
+--- Build a `\includegraphics` LaTeX snippet for an optional image option.
+--- @param path string Image path (already validated as non-empty)
+--- @param width string LaTeX width argument
+--- @return string snippet LaTeX `\includegraphics` call
+local function include_graphics_snippet(path, width)
+  return string.format('\\includegraphics[width=%s]{%s}', width, path)
+end
+
+--- Validate that the recipient address is present and well formed.
+--- @param meta table Pandoc document metadata
+--- @return boolean ok true when validation succeeds
+local function validate_address(meta)
+  if not list_has_entries(meta['address']) then
+    log.log_error(
+      EXTENSION_NAME,
+      "Missing required 'address' field. " ..
+      "Add at least one recipient address line under format.letter-pdf.address."
+    )
+    return false
+  end
+  return true
+end
+
+--- Detect a RawInline carrying an HTML tag inside a Pandoc inline list.
+--- Pandoc parses bare `<tag>` patterns as RawInline format `html`, which the
+--- LaTeX writer drops; surfacing this early avoids silent content loss.
+--- @param value any Pandoc metadata value (MetaInlines or similar)
+--- @return boolean has_raw_html true when raw HTML tokens are present
+local function has_raw_html(value)
+  if value == nil or type(value) ~= 'table' then
+    return false
+  end
+  local found = false
+  pandoc.walk_inline(pandoc.Span(value), {
+    RawInline = function(el)
+      if el.format == 'html' then
+        found = true
+      end
+    end
+  })
+  return found
+end
+
+--- Warn on common front-matter inconsistencies that produce odd output.
+--- @param meta table Pandoc document metadata
+local function warn_on_inconsistencies(meta)
+  local subject_title = meta_to_string(meta['subject-title'])
+  local subject = meta_to_string(meta['subject'])
+  if subject_title ~= '' and subject == '' then
+    log.log_warning(
+      EXTENSION_NAME,
+      "'subject-title' is set but 'subject' is empty; the subject line will be omitted."
+    )
+  end
+
+  if has_raw_html(meta['subject']) or has_raw_html(meta['subject-title']) then
+    log.log_warning(
+      EXTENSION_NAME,
+      "'subject' or 'subject-title' contains raw HTML tokens (e.g. '<x>'); " ..
+      "Pandoc strips these from LaTeX output. Escape with '\\<' / '\\>' or rewrite."
+    )
+  end
+end
+
+--- Prepare the header (letterhead) and signature image hooks in `header-includes`.
+--- The hooks render before the letter body when `header-image` is set, and
+--- replace the closing signature when `signature-image` is set.
+--- Each hook is emitted as a single RawBlock so LaTeX sees one contiguous group.
+--- @param meta table Pandoc document metadata
+--- @return table meta Updated metadata
+local function prepare_image_hooks(meta)
+  local header_image = inlines_to_latex(meta['header-image'])
+  local signature_image = inlines_to_latex(meta['signature-image'])
+
+  if header_image == '' and signature_image == '' then
+    return meta
+  end
+
+  local includes = meta['header-includes']
+  if includes == nil then
+    includes = pandoc.MetaList({})
+  elseif includes.t ~= 'MetaList' then
+    includes = pandoc.MetaList({ includes })
+  end
+
+  local snippets = { '\\usepackage{graphicx}' }
+
+  if header_image ~= '' then
+    local width = resolve_width(meta['header-image-width'], '\\textwidth')
+    snippets[#snippets + 1] = table.concat({
+      '\\makeatletter',
+      '\\let\\letter@oldopening\\opening',
+      '\\renewcommand{\\opening}[1]{%',
+      include_graphics_snippet(header_image, width) .. '%',
+      '\\par\\vspace{1em}%',
+      '\\letter@oldopening{#1}%',
+      '}',
+      '\\makeatother'
+    }, '\n')
+  end
+
+  if signature_image ~= '' then
+    local width = resolve_width(meta['signature-image-width'], '4cm')
+    snippets[#snippets + 1] = table.concat({
+      '\\makeatletter',
+      '\\let\\letter@oldclosing\\closing',
+      '\\renewcommand{\\closing}[1]{%',
+      '\\stopbreaks%',
+      '\\noindent%',
+      '\\ifx\\@empty\\fromaddress\\else%',
+      '\\hspace*{\\longindentation}\\fi%',
+      '\\parbox{\\indentedwidth}{\\raggedright%',
+      '#1\\par\\vspace{0.5em}%',
+      include_graphics_snippet(signature_image, width) .. '%',
+      '\\par\\vspace{0.25em}%',
+      '\\ignorespaces \\fromsig\\strut}\\par%',
+      '}',
+      '\\makeatother'
+    }, '\n')
+  end
+
+  includes:insert(pandoc.MetaBlocks({
+    pandoc.RawBlock('latex', table.concat(snippets, '\n'))
+  }))
+
+  meta['header-includes'] = includes
+  return meta
+end
+
+--- Filter entry point.
+--- Validates required fields and emits a clear, actionable diagnostic on failure.
+--- Note: Quarto continues the pipeline after a Lua filter error, so the render
+--- may still produce a malformed PDF; the early `(E) [letter] ...` diagnostic
+--- makes the cause obvious in the log.
+--- @param meta table Pandoc document metadata
+--- @return table meta Updated metadata
+local function process_meta(meta)
+  if not quarto.doc.is_format('latex') then
+    return meta
+  end
+
+  validate_address(meta)
+  warn_on_inconsistencies(meta)
+  return prepare_image_hooks(meta)
+end
+
+return {
+  { Meta = process_meta }
+}


### PR DESCRIPTION
- Adds a Lua filter wired through `contributes.formats.common.filters` that logs an actionable error when the required `address` field is missing or empty, warns when `subject-title` is set but `subject` is empty, and warns when `subject` or `subject-title` contains raw HTML tokens that Pandoc would silently strip from LaTeX output.
- Adds `header-image` and `header-image-width` options for letterhead images, inserted above the opening salutation via a redefined `\opening`.
- Adds `signature-image` and `signature-image-width` options for digital signature images, inserted between the closing salutation and the printed name via a redefined `\closing`.
- Reconstructs width values verbatim from inline metadata so LaTeX dimensions such as `0.5\textwidth` survive the YAML to Pandoc round trip without being parsed as a markdown escape.
- Adds a `meta-fr` snippet (French letter front matter) and a `meta-sig` snippet (letter with signature image); relabels the existing `meta` snippet as English.
- Declares the four new options in `_schema.yml`.
- Ships the shared `_modules/logging.lua` module so the new filter can emit prefixed diagnostics.
- Documents every front-matter option in a new Configuration table, plus dedicated sections for bilingual variants, letterhead and signature images (including the YAML double-backslash rule for `\textwidth`-style widths), and the diagnostics emitted by the filter.

The `address` field validation was flagged as `[verify]` in the thorough-review brief and is partially valid: missing `address` does not cause LaTeX to fail, but produces a malformed `\begin{letter}{}` block.
The new filter now logs a prefixed `(E) [letter] ...` line so the cause is obvious; Quarto does not abort a render on a Lua filter `error()`, so the diagnostic is logged rather than halting the pipeline.

The `subject-title` LaTeX-escape concern was verified invalid: Pandoc's template engine already escapes `&`, `#`, `%`, `_`, `{`, `}` when interpolating `$subject-title$` as Inlines.
The genuine related issue is that Pandoc parses bare `<word>` as a `RawInline` HTML token that the LaTeX writer drops, which is now surfaced by the new warning rather than papered over with manual escaping.
