### PR TITLE
feat: declare the vendored modules in a manifest

### DIFF
--- a/_extensions/letter/_dependencies.yml
+++ b/_extensions/letter/_dependencies.yml
@@ -1,0 +1,11 @@
+schema: 1
+sources:
+  quarto-lua-modules:
+    origin: "https://github.com/mcanouil/quarto-lua-modules"
+    fetch: "{origin}/releases/download/{version}/{file}"
+    version: "2.1.0"
+    licence: MIT
+    files:
+      logging.lua:
+        sha256: "0c3ded6020d3739c91bb6a492328751b284d1ada5763a1b8ca6fc5536ac01c95"
+        runtime: any

--- a/_extensions/letter/_vendor/quarto-lua-modules/LICENSE
+++ b/_extensions/letter/_vendor/quarto-lua-modules/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mickaël Canouil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/_extensions/letter/_vendor/quarto-lua-modules/logging.lua
+++ b/_extensions/letter/_vendor/quarto-lua-modules/logging.lua
@@ -3,7 +3,7 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 1.0.0
+--- @version 2.1.0
 
 local M = {}
 

--- a/_extensions/letter/letter.lua
+++ b/_extensions/letter/letter.lua
@@ -9,7 +9,7 @@
 --- LaTeX template can render them without bespoke escaping in the partials.
 
 local EXTENSION_NAME = 'letter'
-local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
+local log = require(quarto.utils.resolve_path('_vendor/quarto-lua-modules/logging.lua'):gsub('%.lua$', ''))
 
 --- Convert a metadata value to a trimmed string.
 --- @param value any Pandoc metadata value or nil

--- a/docs/_scripts/sync-extension.sh
+++ b/docs/_scripts/sync-extension.sh
@@ -3,9 +3,9 @@
 # Documentation Extension Sync
 # Mirrors the repository's own extension into the documentation project.
 #
-# @license %%license%%
-# @copyright %%year%% %%author%%
-# @author %%author%%
+# @license MIT License
+# @copyright 2026 Mickaël Canouil
+# @author Mickaël Canouil
 #
 # The website demonstrates the extension it documents, so the extension has to
 # be resolvable from docs/. Quarto builds its extension registry while reading


### PR DESCRIPTION
The shared Lua modules under `_extensions/letter/_modules/` move onto a manifest at `_extensions/letter/_dependencies.yml` with `_extensions/letter/_vendor/`, so each file records the release it came from and can be verified against it.
Only `logging.lua` was vendored here, and it matched `quarto-lua-modules` at 1.0.0, so the manifest declares it at 2.1.0 and the published copy replaces it.
The single difference against the release was the `@version` banner.
`logging.lua` loads no siblings, so the manifest declares one file, and `_vendor/` holds nothing undeclared.
The require at `_extensions/letter/letter.lua:12` now resolves through `_vendor/quarto-lua-modules/logging.lua`.

No schema validation is wired here.
`_extensions/letter/_schema.yml` declares no `options:` block and no `shortcodes:`, only a `formats:` block, and the shared checker exposes only `options` and `call`, so a checker could never report anything about a document.
Nothing is vendored for validation, and the changelog is unchanged because no behaviour changes for users.

Two disagreements between the schema and the code that reads it, both reproduced by render and both left alone.
`address` is declared `type: array` with `minItems: 1` at `_extensions/letter/_schema.yml:11-16`, but `list_has_entries` at `_extensions/letter/letter.lua:28-41` accepts a bare string, and `$for(address)$` at `_extensions/letter/partials/before-body.tex:5` applies it, so a scalar address rendered to PDF with no message.
`header-image-width` is declared `type: string` at `_extensions/letter/_schema.yml:51-54`, so a bare `12` satisfies it, and `resolve_width` at `_extensions/letter/letter.lua:76-82` hands it to `\includegraphics` at `_extensions/letter/letter.lua:89`, where LuaLaTeX stops with `Illegal unit of measure (pt inserted)` and names no option, while `4cm` renders clean.

Checked locally: `vendor.sh --sync` exit 0, the documentation sync exit 0, and `quarto render docs` exit 0 including the letter PDF.
A deliberate-fault probe drew `(E) [letter]` and `(W) [letter]` through the repointed module, which proves the vendored copy is live, and the documented configuration rendered with no message.
